### PR TITLE
Fix parse error in core.lua

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -133,7 +133,7 @@ local parse_file = function(path)
       print(path .. ': invalid line: ' .. line)
     end
   end
-  for i = 1, #config / 2, 1 do
+  for i = 1, math.floor(#config / 2), 1 do
     config[i], config[#config - i + 1] = config[#config - i + 1], config[i]
   end
   return config

--- a/core.lua
+++ b/core.lua
@@ -133,7 +133,7 @@ local parse_file = function(path)
       print(path .. ': invalid line: ' .. line)
     end
   end
-  for i = 1, #config // 2, 1 do
+  for i = 1, #config / 2, 1 do
     config[i], config[#config - i + 1] = config[#config - i + 1], config[i]
   end
   return config


### PR DESCRIPTION
I'm seeing a parse error in core.lua:

```
core.lua:136: unexpected symbol near '/'
```

I don't know Lua, but this looks like a division operator that was accidentally repeated.