### PR TITLE
check if max_line_length can be used as a number before using it

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -29,7 +29,7 @@ local apply = function(win)
       or win.options.tabwidth
     )
   end
-  if settings.max_line_length then
+  if settings.max_line_length and tonumber(settings.max_line_length) then
     win.options.colorcolumn = math.floor(settings.max_line_length + 1)
   end
 end


### PR DESCRIPTION
I encountered the following line in an `.editorconfig`  file in the wild.

```ini
max_line_length = off
```

Since `max_line_length` is not defined by the standard I have no way to tell if this is invalid or not.

Additionally, checking if the value we try to use as a number actually can be used as a number seems good anyway.
